### PR TITLE
set data-cke-saved-href attribute

### DIFF
--- a/dialogs/simplelink.js
+++ b/dialogs/simplelink.js
@@ -31,6 +31,7 @@
         				href = "http://" + href;
         			}
 	            element.setAttribute("href", href);
+	            element.setAttribute("data-cke-saved-href", href);
 	            if(!element.getText()) {
         				element.setText(this.getValue());
         			}

--- a/dialogs/simplelink.js
+++ b/dialogs/simplelink.js
@@ -1,4 +1,5 @@
 ﻿CKEDITOR.dialog.add("simplelinkDialog", function(editor) {
+	var isExternalURL = /^((http|https):\/\/|mailto:)/;
 	return {
 		allowedContent: "a[href,target]",
 		title: "Insert Link",
@@ -15,7 +16,6 @@
 				validate: CKEDITOR.dialog.validate.notEmpty( "url cannot be empty." ),
         setup: function( element ) {
         	var href = element.getAttribute("href");
-        	var isExternalURL = /^(http|https):\/\//;
         	if(href) {
         			if(!isExternalURL.test(href)) {
         				href = "http://" + href;
@@ -25,7 +25,6 @@
         },
         commit: function(element) {
         	var href = this.getValue();
-        	var isExternalURL = /^(http|https):\/\//;
         	if(href) {
         			if(!isExternalURL.test(href)) {
         				href = "http://" + href;


### PR DESCRIPTION
this fixes a bug where changing the href/url of a link wouldn't be updated in the HTML returned by `editor.getData()`.

To reproduce:
1. make a link with `href="/oldlink`
2. save document (using `editor.setData( editor.getData() )`)
3. position cursor in link, click SimpleLink button, update href to `/newlink`
4. save document using `editor.getData()`
5. observe that link has still `href="/oldlink"`
